### PR TITLE
WIP: use direct export_rangemessage.xml endpoint

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,16 +5,16 @@ isbn_hyphenate is a Python library to add hyphens in the right place to an ISBN 
 
 Most libraries for handling ISBNs can not do hyphenation because it requires using a list of prefixes, available from the International ISBN Agency.
 
-isbn_hyphenate can handle both 10 and 13 digit ISBNs, and will keep the number of digits. 
-If the ISBN is malformed (wrong length or invalid characters) an IsbnMalformedError exception is raised. 
-If the correct hyphen positions cannot be determined, an IsbnUnableToHyphenateError exception is raised. 
+isbn_hyphenate can handle both 10 and 13 digit ISBNs, and will keep the number of digits.
+If the ISBN is malformed (wrong length or invalid characters) an IsbnMalformedError exception is raised.
+If the correct hyphen positions cannot be determined, an IsbnUnableToHyphenateError exception is raised.
 This can mean that the input ISBN is wrong, or it is in a range that is not yet in the known list.
 
 isbn_hyphenate is compatible with both Python 2 and 3.
 
 To update the prefix list:
- 1. Download a new RangeMessage.xml file from https://www.isbn-international.org/range_file_generation
- 2. Convert it to Python format: ./isbn_xml2py.py RangeMessage.xml > isbn_lengthmaps.py
+ 1. Download a new export_rangemessage.xml file from https://www.isbn-international.org/export_rangemessage.xml
+ 2. Convert it to Python format: ./isbn_xml2py.py export_rangemessage.xml > isbn_lengthmaps.py
 
 These alternative Python libraries can also hyphenate:
  * python-stdnum http://pypi.python.org/pypi/python-stdnum

--- a/isbn_hyphenate/isbn_lengthmaps.py
+++ b/isbn_hyphenate/isbn_lengthmaps.py
@@ -1,5 +1,5 @@
-# Generated from RangeMessage.xml with isbn_xml2py.py
-# Available from http://www.isbn-international.org/agency?rmxml=1
+# Generated from export_rangemessage.xml with isbn_xml2py.py
+# Available from https://www.isbn-international.org/export_rangemessage.xml
 # MessageDate: Fri, 1 Apr 2022 01:01:34 BST
 # MessageSerialNumber: 4b111fb2-2ad3-42ac-aeab-104f0ad93812
 groups_length = {'978': [{'length': 1, 'max': 5999999, 'min': 0},

--- a/isbn_hyphenate/isbn_xml2py.py
+++ b/isbn_hyphenate/isbn_xml2py.py
@@ -27,7 +27,7 @@ def parse_prefix_length_map(dom):
     return (prefix, length_map)
 
 if len(sys.argv) != 2:
-    print("Usage:\n./isbn_xml2py.py RangeMessage.xml > isbn_lengthmaps.py", file=sys.stderr)
+    print("Usage:\n./isbn_xml2py.py export_rangemessage.xml > isbn_lengthmaps.py", file=sys.stderr)
     sys.exit(2)
 
 def main():
@@ -49,8 +49,8 @@ def main():
     message_serial = get_text(ISBN_range_message.getElementsByTagName("MessageSerialNumber")[0])
     message_date = get_text(ISBN_range_message.getElementsByTagName("MessageDate")[0])
 
-    print('# Generated from RangeMessage.xml with isbn_xml2py.py')
-    print('# Available from http://www.isbn-international.org/agency?rmxml=1')
+    print('# Generated from export_rangemessage.xml with isbn_xml2py.py')
+    print('# Available from https://www.isbn-international.org/export_rangemessage.xml')
     print('# MessageDate: ' + message_date)
     print('# MessageSerialNumber: ' + message_serial)
     print('groups_length = ' + pprint.pformat(groups_length).replace("u'", "'"))


### PR DESCRIPTION
This might require some modification, it looks like the filename is still supposed to be `RangeMessage.xml`, but is is to be fetched directly from `https://www.isbn-international.org/export_rangemessage.xml`

The `Content-Disposition: attachment; filename="RangeMessage.xml"` header field specifies the correct filename:

```
$ curl -I https://www.isbn-international.org/export_rangemessage.xml
HTTP/1.1 200 OK
Date: Sun, 03 Apr 2022 22:00:51 GMT
Server: Apache/2.4.38 (Debian)
Content-Disposition: attachment; filename="RangeMessage.xml"
Content-Transfer-Encoding: binary
Cache-Control: no-cache, public
Last-Modified: Sun, 03 Apr 2022 22:00:52 GMT
X-UA-Compatible: IE=edge
Content-language: en
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Permissions-Policy: interest-cohort=()
Expires: Sun, 19 Nov 1978 05:00:00 GMT
X-Generator: Drupal 9 (https://www.drupal.org)
Content-Length: 182481
Accept-Ranges: bytes
Content-Type: text/xml;charset=UTF-8

```

**TODO:** Update the documentation in a way that retains the `RangeMessage.xml` filename, but used the direct export URL.
