### PR TITLE
Range files are not expecting ISBN10 checkdigit X 

### DIFF
--- a/isbn_hyphenate/isbn_hyphenate.py
+++ b/isbn_hyphenate/isbn_hyphenate.py
@@ -41,7 +41,7 @@ def hyphenate(input_data):
             input_data = unicode(input_data)
             return_ascii = True
 
-    without_hyphens = re.sub('[\s-]', '', input_data)
+    without_hyphens = re.sub(r'[\s-]', '', input_data)
     
     # Must be digits, maybe an X at the end
     if not re.match('^[0-9]+X?$', without_hyphens):
@@ -78,7 +78,7 @@ def hyphenate(input_data):
     without_hyphens = without_hyphens[group_prefix_length:]
     with_hyphens += group_prefix + '-'
     
-    first7 = int(without_hyphens[:7].ljust(7, '0'))
+    first7 = int(without_hyphens[:7].replace('X', '0').ljust(7, '0'))
     publisher_length = None
     GS1_and_group = GS1_prefix + '-' + group_prefix
     if GS1_and_group not in isbn_lengthmaps.publisher_length:

--- a/isbn_hyphenate/test/isbn_hyphenate_test.py
+++ b/isbn_hyphenate/test/isbn_hyphenate_test.py
@@ -26,6 +26,8 @@ class KnownValues(unittest.TestCase):
                     "978-99953-838-2-4",
                     "978-99930-75-89-9",
                     "978-1-59059-356-1",
+                    "968-9084-02-X",
+                    "9953-37-256-X",
                   )
 
     def test_hyphenating_known_values(self):

--- a/isbn_hyphenate/test/isbn_hyphenate_test.py
+++ b/isbn_hyphenate/test/isbn_hyphenate_test.py
@@ -6,6 +6,7 @@ import isbn_hyphenate
 import unittest
 import sys
 
+
 class KnownValues(unittest.TestCase):
     knownValues = ( "99921-58-10-7",
                     "9971-5-0210-0",
@@ -49,12 +50,15 @@ class KnownValues(unittest.TestCase):
 class BadInput(unittest.TestCase):
     def test_bad_characters(self):
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "fghdf hdfjhfgj")
+
     def test_bad_characters2(self):
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "085131ffff")
+
     def test_bad_charactersX(self):
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "X604250590")
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "960X250590")
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "96042X0590")
+
     def test_try_bad_characters(self):
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.try_hyphenate, "fghdf hdfjhfgj")
 
@@ -82,6 +86,7 @@ class BadInput(unittest.TestCase):
 
     def test_empty_input(self):
         self.assertRaises(isbn_hyphenate.IsbnMalformedError, isbn_hyphenate.hyphenate, "")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes https://github.com/TorKlingberg/isbn_hyphenate/issues/2

It seems the correct thing to do would be to separate out the checkdigit early, and determine the rest of the hyphenation based on the GS1 prefix + 9 remaining digits.

Doing this would involve a refactor, and re-naming things. 

This fix simply replaces any `X`s in the string when they are used in range comparisons.

The variable name `first7` confused me, but the official range files use 7 digit ranges even when the remaining digits are less than seven, e.g. `978-99923` range: `0000000-1999999`.